### PR TITLE
Limiting Doctrine/ORM composer bundle to pass CI tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "2.3.*",
-        "doctrine/orm": "~2.2,>=2.2.3",
+        "doctrine/orm": "~2.2,>=2.2.3,<=2.4.8",
         "doctrine/doctrine-bundle": "1.2.*",
         "twig/extensions": "1.0.*",
         "symfony/swiftmailer-bundle": "2.3.*",


### PR DESCRIPTION
Tests are failing because `doctrine/orm` version was too high and only supported by PHP 5.5

`composer.json` was updated to limit the `doctrine/orm` version to <= 2.4.8

Alternatively the requested PHP version could be updated to >=5.5
